### PR TITLE
Exercise the entire width of possible seeds in tests, remove seed_from_u64 impl

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -71,8 +71,4 @@ impl SeedableRng for ShiShuARng {
     fn from_seed(seed: Self::Seed) -> Self {
         Self::new(bytemuck::cast(seed))
     }
-
-    fn seed_from_u64(seed: u64) -> Self {
-        Self::new([seed, 0, 0, 0])
-    }
 }


### PR DESCRIPTION
I was slightly worried that the higher-indexed lanes would be underexercised in the test, so I changed the tests to make a non-0 seed in tests where a non-0 seed is used. This also lets us remove the `seed_from_u64` impl for SeedableRng and use the default one, which I think might be desirable.