### PR TITLE
Add a criterion benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,11 @@ license = "MIT OR Apache-2.0"
 description = "Port of the shishua rng algorithm to Rust"
 repository = "https://github.com/dbartussek/shishua_rs"
 
+[[bench]]
+name = "bench"
+harness = false
+
+
 [features]
 nightly = ["bytemuck/nightly_portable_simd"]
 rand = ["rand_core"]
@@ -17,3 +22,7 @@ default = ["rand"]
 bytemuck = "1.24.0"
 byteorder = "1.5.0"
 rand_core = { version = "0.9.3", optional = true, default-features = false }
+
+[dev-dependencies]
+criterion = "0.7.0"
+rand = "0.9.2"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,18 @@
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+use rand::prelude::*;
+use shishua::ShiShuARng;
+
+pub fn benchmark_shisuha(c: &mut Criterion) {
+    let length = 1024 * 1024;
+    let mut rng = ShiShuARng::from_os_rng();
+    let mut bytes = vec![0; length];
+    let mut group = c.benchmark_group("throughput");
+    group.throughput(Throughput::Bytes(bytes.len() as u64));
+    group.bench_function("filling 1MB", |b| {
+        b.iter(|| rng.fill(bytes.as_mut_slice()))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_shisuha);
+criterion_main!(benches);


### PR DESCRIPTION
As promised in #3, this adds a criterion benchmark for the RNG throughput.

One thing I noticed is that when I started writing the benchmark (that was on the nightly-only std::simd version on f1bff711c5169d3efad5d306cd51a574b753426c), it tested to a throughput of ~500MiB/s on my M1 macbook pro.

Now, with `wide`, it achieves a throughput of 104.28 MiB/s on the same machine. I guess there's an intrinsic that I'm missing! Needs more data, apparently ((: