### PR TITLE
Add large-period variant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,8 @@ wide = { version = "1.3.0", optional = true }
 cc = { version = "1.2.41", optional = true }
 
 [dev-dependencies]
-criterion = "0.7.0"
+criterion = "0.8.2"
 rand = "0.9.2"
+
+[target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dev-dependencies]
+criterion-cycles-per-byte = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ __intern_c_bindings = ["cc"]
 [dependencies]
 bytemuck = "1.24.0"
 rand_core = { version = "0.9.3", optional = true, default-features = false }
-wide = { version = "0.8.1", optional = true }
+wide = { version = "1.3.0", optional = true }
 
 [build-dependencies]
 cc = { version = "1.2.41", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ harness = false
 
 [features]
 nightly = ["bytemuck/nightly_portable_simd"]
-rand = ["rand_core"]
+rand = ["dep:rand", "rand_core"]
 wide = ["dep:wide"]
 
 default = ["rand"]
@@ -24,7 +24,8 @@ __intern_c_bindings = ["cc"]
 
 [dependencies]
 bytemuck = "1.24.0"
-rand_core = { version = "0.9.3", optional = true, default-features = false }
+rand = { version = "0.10.1", optional = true, default-features = false }
+rand_core = { version = "0.10.1", optional = true, default-features = false }
 wide = { version = "1.3.0", optional = true }
 
 [build-dependencies]
@@ -32,7 +33,7 @@ cc = { version = "1.2.41", optional = true }
 
 [dev-dependencies]
 criterion = "0.8.2"
-rand = "0.9.2"
+rand = "0.10.1"
 
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dev-dependencies]
 criterion-cycles-per-byte = "0.8.0"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -2,7 +2,9 @@ use criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
 };
 use rand::prelude::*;
-use shishua::ShiShuARng;
+use shishua::{
+    CounterUpdate, GenericShiShuARng, LongPeriodShiShuARng, ShiShuARng,
+};
 
 
 #[cfg(feature = "__intern_c_bindings")]
@@ -14,17 +16,27 @@ extern "C" {
 
 
 pub fn benchmark_shisuha(c: &mut Criterion) {
-    const KB: usize = 1024;
-    const MB: usize = 1024 * 1024;
-
     let seed = [0x1, 0x2, 0x3, 0x4];
 
-    let mut rng = ShiShuARng::new(seed);
-    #[cfg(feature = "__intern_c_bindings")]
-    let native_rng = unsafe { shishua_bindings_init(seed.as_ptr()) };
+    benchmark_shishua_generic(c, "ShiShuARng", ShiShuARng::new(seed), true);
+    benchmark_shishua_generic(
+        c,
+        "LongPeriodShiShuARng",
+        LongPeriodShiShuARng::new(seed),
+        false,
+    );
+}
 
-    let mut group = c.benchmark_group("throughput");
-
+fn benchmark_shishua_generic<T: CounterUpdate>(
+    c: &mut Criterion,
+    name: &'static str,
+    mut rng: GenericShiShuARng<T>,
+    #[cfg_attr(not(feature = "__intern_c_bindings"), allow(unused_variables))]
+    include_native: bool,
+) {
+    let mut group = c.benchmark_group(name);
+    const KB: usize = 1024;
+    const MB: usize = 1024 * 1024;
     for size in [512, KB, MB] {
         assert_eq!(size % 512, 0);
 
@@ -42,17 +54,26 @@ pub fn benchmark_shisuha(c: &mut Criterion) {
         group.bench_function(BenchmarkId::new(SHISHUARS_NAME, size), |b| {
             b.iter(|| rng.fill(buffer.as_mut_slice()))
         });
-
         #[cfg(feature = "__intern_c_bindings")]
-        group.bench_function(BenchmarkId::new("shishua_c", size), |b| {
-            b.iter(|| unsafe {
-                shishua_bindings_generate(native_rng, buffer.as_mut_ptr(), size)
+        if include_native {
+            let native_rng = unsafe { shishua_bindings_init(seed.as_ptr()) };
+
+            group.bench_function(BenchmarkId::new("shishua_c", size), |b| {
+                b.iter(|| unsafe {
+                    shishua_bindings_generate(
+                        native_rng,
+                        buffer.as_mut_ptr(),
+                        size,
+                    )
+                });
             });
-        });
+        }
     }
 
     #[cfg(feature = "__intern_c_bindings")]
-    unsafe {shishua_bindings_destroy(native_rng)};
+    unsafe {
+        shishua_bindings_destroy(native_rng)
+    };
     group.finish();
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,3 +1,4 @@
+use core::hint::black_box;
 use criterion::{
     criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
 };
@@ -52,7 +53,10 @@ fn benchmark_shishua_generic<T: CounterUpdate>(
         const SHISHUARS_NAME: &str = "shishua_rs_nightly";
 
         group.bench_function(BenchmarkId::new(SHISHUARS_NAME, size), |b| {
-            b.iter(|| rng.fill(buffer.as_mut_slice()))
+            b.iter(|| {
+                rng.fill(buffer.as_mut_slice());
+                black_box(buffer);
+            })
         });
         #[cfg(feature = "__intern_c_bindings")]
         if include_native {
@@ -64,7 +68,8 @@ fn benchmark_shishua_generic<T: CounterUpdate>(
                         native_rng,
                         buffer.as_mut_ptr(),
                         size,
-                    )
+                    );
+                    black_box(buffer);
                 });
             });
         }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,6 +1,6 @@
 use core::hint::black_box;
 use criterion::{
-    criterion_group, criterion_main, BenchmarkId, Criterion, Throughput,
+    criterion_group, criterion_main, BenchmarkId, Criterion, measurement::Measurement, Throughput,
 };
 use rand::prelude::*;
 use shishua::{
@@ -16,7 +16,7 @@ extern "C" {
 }
 
 
-pub fn benchmark_shisuha(c: &mut Criterion) {
+pub fn benchmark_shisuha<M: Measurement>(c: &mut Criterion<M>) {
     let seed = [0x1, 0x2, 0x3, 0x4];
 
     benchmark_shishua_generic(c, "ShiShuARng", ShiShuARng::new(seed), true);
@@ -28,8 +28,8 @@ pub fn benchmark_shisuha(c: &mut Criterion) {
     );
 }
 
-fn benchmark_shishua_generic<T: CounterUpdate>(
-    c: &mut Criterion,
+fn benchmark_shishua_generic<M: Measurement, T: CounterUpdate>(
+    c: &mut Criterion<M>,
     name: &'static str,
     mut rng: GenericShiShuARng<T>,
     #[cfg_attr(not(feature = "__intern_c_bindings"), allow(unused_variables))]
@@ -55,7 +55,7 @@ fn benchmark_shishua_generic<T: CounterUpdate>(
         group.bench_function(BenchmarkId::new(SHISHUARS_NAME, size), |b| {
             b.iter(|| {
                 rng.fill(buffer.as_mut_slice());
-                black_box(buffer);
+                black_box(buffer.as_slice());
             })
         });
         #[cfg(feature = "__intern_c_bindings")]
@@ -69,7 +69,7 @@ fn benchmark_shishua_generic<T: CounterUpdate>(
                         buffer.as_mut_ptr(),
                         size,
                     );
-                    black_box(buffer);
+                    black_box(buffer.as_slice());
                 });
             });
         }
@@ -81,6 +81,12 @@ fn benchmark_shishua_generic<T: CounterUpdate>(
     };
     group.finish();
 }
-
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_measurement(criterion_cycles_per_byte::CyclesPerByte);
+    targets = benchmark_shisuha
+);
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
 criterion_group!(benches, benchmark_shisuha);
 criterion_main!(benches);

--- a/src/core.rs
+++ b/src/core.rs
@@ -39,6 +39,16 @@ const PHI: [u64; 16] = [
     0xFEC507705E4AE6E5,
 ];
 
+#[inline(always)]
+fn add256(a: u64x4, b: u64x4) -> u64x4 {
+    let (r0, c0) = a[0].overflowing_add(b[0]);
+    let (r1, c1) = a[1].overflowing_add(b[1] + (c0 as u64));
+    let (r2, c2) = a[2].overflowing_add(b[2] + (c1 as u64));
+    let (r3, _)  = a[3].overflowing_add(b[3] + (c2 as u64));
+
+    u64x4::from([r0, r1, r2, r3])
+}
+
 const fn correct_index(index: usize) -> usize {
     (u32x8::LEN - 1 - index) ^ 1
 }
@@ -81,8 +91,7 @@ pub struct LongPeriodCounterUpdate;
 impl CounterUpdate for LongPeriodCounterUpdate {
     #[inline(always)]
     fn update(&mut self, counter: &mut u64x4) {
-        *counter += u64x4::from([0, 0, 0, PHI[0]]);
-        *counter = shuffle_u64_as_u32!(*counter, ROTATE_3);
+        *counter = add256(*counter, u64x4::from([PHI[0], PHI[1], PHI[2], PHI[3]]));
     }
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -39,22 +39,73 @@ const PHI: [u64; 16] = [
     0xFEC507705E4AE6E5,
 ];
 
-/// The raw ShiShuA implementation. Random values are generated in `[u64; 16]` chunks with [round_unpack](ShiShuAState::round_unpack).
+const fn correct_index(index: usize) -> usize {
+    (u32x8::LEN - 1 - index) ^ 1
+}
+const ROTATE_3: [usize; 8] = [
+    correct_index(3),
+    correct_index(4),
+    correct_index(1),
+    correct_index(2),
+    correct_index(7),
+    correct_index(0),
+    correct_index(5),
+    correct_index(6),
+];
+
+macro_rules! shuffle_u64_as_u32 {
+    ($data:expr, $shuffle:expr) => {{
+        let as_u32: u32x8 = bytemuck::cast($data);
+        let shuffled = simd_swizzle!(as_u32, $shuffle);
+        bytemuck::cast(shuffled)
+    }};
+}
+
+pub trait CounterUpdate: Copy + Clone {
+    fn update(&mut self, counter: &mut u64x4);
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct BasicCounterUpdate;
+
+impl CounterUpdate for BasicCounterUpdate {
+    #[inline(always)]
+    fn update(&mut self, counter: &mut u64x4) {
+        *counter += u64x4::from([1, 3, 5, 7]);
+    }
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct LongPeriodCounterUpdate;
+
+impl CounterUpdate for LongPeriodCounterUpdate {
+    #[inline(always)]
+    fn update(&mut self, counter: &mut u64x4) {
+        *counter += u64x4::from([0, 0, 0, PHI[0]]);
+        *counter = shuffle_u64_as_u32!(*counter, ROTATE_3);
+    }
+}
+
+/// The raw ShiShuA implementation. Random values are generated in `[u64; 16]` chunks with [round_unpack](GenericShiShuAState::round_unpack).
 #[derive(Copy, Clone)]
-pub struct ShiShuAState {
+pub struct GenericShiShuAState<C: CounterUpdate> {
     state: [u64x4; STATE_SIZE],
     output: [u64x4; STATE_SIZE],
     counter: u64x4,
+    counter_update: C,
 }
 
-impl ShiShuAState {
+pub type ShiShuAState = GenericShiShuAState<BasicCounterUpdate>;
+pub type LongPeriodShiShuAState = GenericShiShuAState<LongPeriodCounterUpdate>;
+
+impl<C: CounterUpdate + Default> GenericShiShuAState<C> {
     pub fn new(seed: [u64; STATE_LANES]) -> Self {
         const STEPS: usize = 13;
         const ROUNDS: usize = 1;
 
         let mut buffer = [0u64; STATE_LANES * STATE_SIZE * ROUNDS];
 
-        let mut state = ShiShuAState {
+        let mut state = GenericShiShuAState {
             state: [
                 u64x4::from([
                     PHI[3],
@@ -83,6 +134,7 @@ impl ShiShuAState {
             ],
             output: [u64x4::splat(0); 4],
             counter: u64x4::splat(0),
+            counter_update: Default::default(),
         };
 
         for _ in 0..STEPS {
@@ -95,7 +147,10 @@ impl ShiShuAState {
 
         state
     }
+}
 
+
+impl<C: CounterUpdate> GenericShiShuAState<C> {
     fn generate(&mut self, output_slice: &mut [u64]) {
         assert_eq!(output_slice.len() % (STATE_LANES * STATE_SIZE), 0);
 
@@ -124,10 +179,6 @@ impl ShiShuAState {
 
     #[inline(always)]
     fn round(&mut self) -> [u64x4; STATE_SIZE] {
-        const fn correct_index(index: usize) -> usize {
-            (u32x8::LEN - 1 - index) ^ 1
-        }
-
         // Shuffle values work differently in Rust than in the C source.
         //
         // High and low 32 bits are flipped.
@@ -136,16 +187,7 @@ impl ShiShuAState {
         // I spent quite some time figuring this out.
         const SHUFFLE: [[usize; 8]; 2] = [
             // [4, 3, 2, 1, 0, 7, 6, 5],
-            [
-                correct_index(3),
-                correct_index(4),
-                correct_index(1),
-                correct_index(2),
-                correct_index(7),
-                correct_index(0),
-                correct_index(5),
-                correct_index(6),
-            ],
+            ROTATE_3,
             // [2, 1, 0, 7, 6, 5, 4, 3],
             [
                 correct_index(1),
@@ -159,32 +201,22 @@ impl ShiShuAState {
             ],
         ];
 
-        let increment = u64x4::from([1, 3, 5, 7]);
-
-        let ShiShuAState {
+        let GenericShiShuAState {
             state,
             output,
             counter,
+            counter_update,
         } = self;
 
         // Perform the round
         state[1] += *counter;
         state[3] += *counter;
-        *counter += increment;
+        counter_update.update(counter);
 
         let u0 = state[0] >> 1;
         let u1 = state[1] >> 3;
         let u2 = state[2] >> 1;
         let u3 = state[3] >> 3;
-
-        macro_rules! shuffle_u64_as_u32 {
-            ($data:expr, $shuffle:expr) => {{
-                let as_u32: u32x8 = bytemuck::cast($data);
-                let shuffled = simd_swizzle!(as_u32, $shuffle);
-                bytemuck::cast(shuffled)
-            }};
-        }
-
 
         let t0: u64x4 = shuffle_u64_as_u32!(state[0], SHUFFLE[0]);
         let t1: u64x4 = shuffle_u64_as_u32!(state[1], SHUFFLE[1]);

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,9 +1,9 @@
 #[cfg(all(not(feature = "nightly"), not(feature = "wide")))]
-use crate::software_simd::*;
+pub(crate) use crate::software_simd::*;
 #[cfg(feature = "nightly")]
-use core::simd::{simd_swizzle, u32x8, u64x4};
+pub(crate) use core::simd::{simd_swizzle, u32x8, u64x4};
 #[cfg(all(not(feature = "nightly"), feature = "wide"))]
-use {
+pub(crate) use {
     crate::wide_support::*,
     wide::{u32x8, u64x4},
 };
@@ -91,7 +91,7 @@ impl CounterUpdate for LongPeriodCounterUpdate {
 pub struct GenericShiShuAState<C: CounterUpdate> {
     state: [u64x4; STATE_SIZE],
     output: [u64x4; STATE_SIZE],
-    counter: u64x4,
+    pub(crate) counter: u64x4,
     counter_update: C,
 }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -45,14 +45,16 @@ fn add256(a: u64x4, b: u64x4) -> u64x4 {
     //
     // Step 1: parallel wrapping add across all 4 lanes (single SIMD op).
     let sum = a + b;
+    let sum_arr = sum.to_array();
+    let a_arr = a.to_array();
 
     // Step 2: compute per-lane generate and propagate bits.
     // All 5 comparisons are independent — maximum ILP.
-    let g0 = sum[0] < a[0]; // lane 0 overflowed
-    let g1 = sum[1] < a[1]; // lane 1 overflowed
-    let g2 = sum[2] < a[2]; // lane 2 overflowed
-    let p1 = sum[1] == u64::MAX; // lane 1 would propagate a carry-in
-    let p2 = sum[2] == u64::MAX; // lane 2 would propagate a carry-in
+    let g0 = sum_arr[0] < a_arr[0]; // lane 0 overflowed
+    let g1 = sum_arr[1] < a_arr[1]; // lane 1 overflowed
+    let g2 = sum_arr[2] < a_arr[2]; // lane 2 overflowed
+    let p1 = sum_arr[1] == u64::MAX; // lane 1 would propagate a carry-in
+    let p2 = sum_arr[2] == u64::MAX; // lane 2 would propagate a carry-in
 
     // Step 3: carry-lookahead propagation (short boolean chain).
     let c0 = g0;

--- a/src/core.rs
+++ b/src/core.rs
@@ -41,12 +41,26 @@ const PHI: [u64; 16] = [
 
 #[inline(always)]
 fn add256(a: u64x4, b: u64x4) -> u64x4 {
-    let (r0, c0) = a[0].overflowing_add(b[0]);
-    let (r1, c1) = a[1].overflowing_add(b[1] + (c0 as u64));
-    let (r2, c2) = a[2].overflowing_add(b[2] + (c1 as u64));
-    let (r3, _)  = a[3].overflowing_add(b[3] + (c2 as u64));
+    // Vectorized 256-bit add: two SIMD adds with scalar carry-lookahead between.
+    //
+    // Step 1: parallel wrapping add across all 4 lanes (single SIMD op).
+    let sum = a + b;
 
-    u64x4::from([r0, r1, r2, r3])
+    // Step 2: compute per-lane generate and propagate bits.
+    // All 5 comparisons are independent — maximum ILP.
+    let g0 = sum[0] < a[0]; // lane 0 overflowed
+    let g1 = sum[1] < a[1]; // lane 1 overflowed
+    let g2 = sum[2] < a[2]; // lane 2 overflowed
+    let p1 = sum[1] == u64::MAX; // lane 1 would propagate a carry-in
+    let p2 = sum[2] == u64::MAX; // lane 2 would propagate a carry-in
+
+    // Step 3: carry-lookahead propagation (short boolean chain).
+    let c0 = g0;
+    let c1 = g1 | (p1 & c0);
+    let c2 = g2 | (p2 & c1);
+
+    // Step 4: apply carries with a single SIMD add.
+    sum + u64x4::from([0, c0 as u64, c1 as u64, c2 as u64])
 }
 
 const fn correct_index(index: usize) -> usize {
@@ -217,10 +231,15 @@ impl<C: CounterUpdate> GenericShiShuAState<C> {
             counter_update,
         } = self;
 
-        // Perform the round
-        state[1] += *counter;
-        state[3] += *counter;
+        // Save current counter and start the update immediately.
+        // For LongPeriodCounterUpdate the update is a multi-cycle carry chain;
+        // starting it here maximizes overlap with the independent state[0]/state[2]
+        // work below, hiding the carry-chain latency before the next round.
+        let counter_val = *counter;
         counter_update.update(counter);
+
+        state[1] += counter_val;
+        state[3] += counter_val;
 
         let u0 = state[0] >> 1;
         let u1 = state[1] >> 3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ mod wide_support;
 #[cfg(all(not(feature = "nightly"), not(feature = "wide")))]
 mod software_simd;
 
-pub use crate::core::ShiShuAState;
+pub use crate::core::{
+    BasicCounterUpdate, CounterUpdate, GenericShiShuAState,
+    LongPeriodCounterUpdate, LongPeriodShiShuAState, ShiShuAState,
+};
 #[cfg(feature = "rand")]
-pub use crate::rand::ShiShuARng;
+pub use crate::rand::{GenericShiShuARng, LongPeriodShiShuARng, ShiShuARng};

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,6 +1,6 @@
 use crate::{
-    core::{STATE_LANES, STATE_SIZE},
-    ShiShuAState,
+    core::{BasicCounterUpdate, CounterUpdate, STATE_LANES, STATE_SIZE},
+    GenericShiShuAState,
 };
 use rand_core::{RngCore, SeedableRng};
 
@@ -10,21 +10,27 @@ const STATE_WRAPPER_BUFFER_SIZE: usize =
 /// A rand compatible wrapper around the raw ShiShuAState.
 ///
 /// An internal buffer is used to split up big chunks of randomness into the requested size.
-pub struct ShiShuARng {
-    state: ShiShuAState,
+pub struct GenericShiShuARng<C: CounterUpdate> {
+    state: GenericShiShuAState<C>,
     buffer: [u8; STATE_WRAPPER_BUFFER_SIZE],
     buffer_index: usize,
 }
 
-impl ShiShuARng {
+pub type ShiShuARng = GenericShiShuARng<BasicCounterUpdate>;
+pub type LongPeriodShiShuARng =
+    GenericShiShuARng<crate::core::LongPeriodCounterUpdate>;
+
+impl<C: CounterUpdate + Default> GenericShiShuARng<C> {
     pub fn new(seed: [u64; STATE_LANES]) -> Self {
-        ShiShuARng {
-            state: ShiShuAState::new(seed),
+        GenericShiShuARng {
+            state: GenericShiShuAState::new(seed),
             buffer: [0; STATE_WRAPPER_BUFFER_SIZE],
             buffer_index: STATE_WRAPPER_BUFFER_SIZE,
         }
     }
+}
 
+impl<C: CounterUpdate> GenericShiShuARng<C> {
     #[inline(always)]
     pub fn get_byte(&mut self) -> u8 {
         if self.buffer_index >= STATE_WRAPPER_BUFFER_SIZE {
@@ -47,7 +53,7 @@ impl ShiShuARng {
     }
 }
 
-impl RngCore for ShiShuARng {
+impl<C: CounterUpdate> RngCore for GenericShiShuARng<C> {
     fn next_u32(&mut self) -> u32 {
         let mut buffer = [0u8; size_of::<u32>()];
         self.fill_bytes(&mut buffer);
@@ -85,7 +91,7 @@ impl RngCore for ShiShuARng {
     }
 }
 
-impl SeedableRng for ShiShuARng {
+impl<C: CounterUpdate + Default> SeedableRng for GenericShiShuARng<C> {
     type Seed = [u8; STATE_LANES * size_of::<u64>()];
 
     fn from_seed(seed: Self::Seed) -> Self {

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,7 +1,8 @@
 use crate::{
-    core::{BasicCounterUpdate, CounterUpdate, STATE_LANES, STATE_SIZE},
+    core::{u64x4, BasicCounterUpdate, CounterUpdate, STATE_LANES, STATE_SIZE},
     GenericShiShuAState,
 };
+use core::convert::TryInto;
 use rand_core::{RngCore, SeedableRng};
 
 const STATE_WRAPPER_BUFFER_SIZE: usize =
@@ -27,6 +28,24 @@ impl<C: CounterUpdate + Default> GenericShiShuARng<C> {
             buffer: [0; STATE_WRAPPER_BUFFER_SIZE],
             buffer_index: STATE_WRAPPER_BUFFER_SIZE,
         }
+    }
+
+    pub fn new_with_large_seed(seed: [u64; STATE_LANES * 2]) -> Self {
+        let main_seed: [u64; STATE_LANES] = seed[0..STATE_LANES].try_into().unwrap();
+        let counter_seed: [u64; STATE_LANES] =
+            seed[STATE_LANES..].try_into().unwrap();
+
+        // Ensure that counter uses seed, but that similar seeds don't result in similar positions
+        // in the same cycle.
+        let mut counter_deriver = Self::new(counter_seed);
+        counter_deriver.state.counter = u64x4::from(main_seed);
+        let mut counter_from_base = [0u64; STATE_LANES];
+        counter_deriver
+            .fill_bytes(bytemuck::cast_slice_mut(&mut counter_from_base));
+
+        let mut new = Self::new(main_seed);
+        new.state.counter = u64x4::from(counter_seed);
+        new
     }
 }
 

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -3,7 +3,9 @@ use crate::{
     GenericShiShuAState,
 };
 use core::convert::TryInto;
-use rand_core::{RngCore, SeedableRng};
+use core::convert::Infallible;
+use rand::TryRng;
+use rand_core::{SeedableRng};
 
 const STATE_WRAPPER_BUFFER_SIZE: usize =
     STATE_LANES * STATE_SIZE * size_of::<u64>();
@@ -41,7 +43,7 @@ impl<C: CounterUpdate + Default> GenericShiShuARng<C> {
         counter_deriver.state.counter = u64x4::from(main_seed);
         let mut counter_from_base = [0u64; STATE_LANES];
         counter_deriver
-            .fill_bytes(bytemuck::cast_slice_mut(&mut counter_from_base));
+            .try_fill_bytes(bytemuck::cast_slice_mut(&mut counter_from_base)).unwrap();
 
         let mut new = Self::new(main_seed);
         new.state.counter = u64x4::from(counter_seed);
@@ -72,20 +74,21 @@ impl<C: CounterUpdate> GenericShiShuARng<C> {
     }
 }
 
-impl<C: CounterUpdate> RngCore for GenericShiShuARng<C> {
-    fn next_u32(&mut self) -> u32 {
+impl<C: CounterUpdate> TryRng for GenericShiShuARng<C> {
+    type Error = Infallible;
+    fn try_next_u32(&mut self) -> Result<u32, Infallible> {
         let mut buffer = [0u8; size_of::<u32>()];
-        self.fill_bytes(&mut buffer);
-        u32::from_le_bytes(buffer)
+        self.try_fill_bytes(&mut buffer)?;
+        Ok(u32::from_le_bytes(buffer))
     }
 
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Infallible> {
         let mut buffer = [0u8; size_of::<u64>()];
-        self.fill_bytes(&mut buffer);
-        u64::from_le_bytes(buffer)
+        self.try_fill_bytes(&mut buffer)?;
+        Ok(u64::from_le_bytes(buffer))
     }
 
-    fn fill_bytes(&mut self, mut dest: &mut [u8]) {
+    fn try_fill_bytes(&mut self, mut dest: &mut [u8]) -> Result<(), Infallible> {
         while self.buffer_index < STATE_WRAPPER_BUFFER_SIZE && dest.len() > 0 {
             dest[0] = self.buffer[self.buffer_index];
             self.buffer_index += 1;
@@ -107,6 +110,8 @@ impl<C: CounterUpdate> RngCore for GenericShiShuARng<C> {
         for byte in dest.iter_mut() {
             *byte = self.get_byte();
         }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
When all of a large combinatorial class of results, e.g. all possible shuffles of a 52-card deck, need to be possible in a random function, the PRNG needs a period larger than 2^64 output blocks.

This PR introduces LongPeriodShiShuAState and LongPeriodShiShuARng, which increase the period to 2^256 output blocks by replacing the lanewise increments with a true 256-bit addition. This is slightly slower, but should still be close to the fastest *for its period length*, and it keeps the same small state. It also introduces `new_with_large_seed`, which uses the seed to initialize the state *including the counter* randomly.

I've tested this variant in PractRand, and it has passed. The amounts tested were: 4096 seeds @ 1 GiB, 128 seeds @ 128 GiB, 16 seeds @ 1 TiB, 8 seeds @ 32 TiB (with results reported every 2 TiB in addition to the default power-of-2 schedule). On these, PractRand reports no failures, and 1028, 68, 4 and 0 seeds with anomalies rated "unusual", "mildly suspicious", "suspicious" and "very suspicious" respectively (compared to 1010, 62, 4 and 1 on unmodified shishua-rs).

The generification of `round()` was performed without genAI; the initial implementation of `add256()` is by ChatGPT; optimizations are by Claude Opus 4.6.